### PR TITLE
feat(config): add support for custom configuration file and merge settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ a.http
 .idea/GitLink.xml
 dictionary.txt
 /logs
+
+# 自定义配置文件，避免意外提交敏感信息
+custom.yaml

--- a/chat_v2/chat.go
+++ b/chat_v2/chat.go
@@ -6,13 +6,14 @@ import (
 	"csust-got/config"
 	"csust-got/entities"
 	"csust-got/util"
-	"github.com/sashabaranov/go-openai"
-	"go.uber.org/zap"
-	tb "gopkg.in/telebot.v3"
 	"net/http"
 	"net/url"
 	"strings"
 	"text/template"
+
+	"github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
+	tb "gopkg.in/telebot.v3"
 )
 
 var clients map[string]*openai.Client

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -102,6 +103,19 @@ func initViper(configFile, envPrefix string) {
 		if err := viper.ReadInConfig(); err != nil {
 			zap.L().Warn("an error was produced when reading config!", zap.String("configFile", configFile), zap.Error(err))
 			return
+		}
+
+		// 检查同一目录下是否存在custom.yaml文件
+		customConfigFile := filepath.Join(filepath.Dir(configFile), "custom.yaml")
+		v := viper.New()
+		v.SetConfigFile(customConfigFile)
+		if err := v.ReadInConfig(); err == nil {
+			// 成功读取了custom.yaml，合并配置
+			if err := viper.MergeConfigMap(v.AllSettings()); err != nil {
+				zap.L().Warn("an error was produced when merging custom config!", zap.String("customConfigFile", customConfigFile), zap.Error(err))
+			} else {
+				zap.L().Info("custom config merged successfully", zap.String("customConfigFile", customConfigFile))
+			}
 		}
 	}
 	viper.SetEnvPrefix(envPrefix)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -219,4 +220,30 @@ func TestChatConfigV2(t *testing.T) {
 	req.Len(*BotConfig.ChatConfigV2, 1)
 	req.NotNil((*BotConfig.ChatConfigV2)[0].Model)
 	req.NotEmpty((*BotConfig.ChatConfigV2)[0].Model.Model)
+}
+
+func TestCustomConfig(t *testing.T) {
+	req := testInit(t)
+
+	// 创建临时配置文件
+	tempDir := t.TempDir()
+
+	// 创建基础配置文件
+	baseConfigPath := filepath.Join(tempDir, "config.yaml")
+	err := os.WriteFile(baseConfigPath, []byte("debug: false\ntoken: base-token"), 0644)
+	req.NoError(err)
+
+	// 创建自定义配置文件
+	customConfigPath := filepath.Join(tempDir, "custom.yaml")
+	err = os.WriteFile(customConfigPath, []byte("debug: true\ntoken: custom-token"), 0644)
+	req.NoError(err)
+
+	// 初始化配置
+	BotConfig = NewBotConfig()
+	initViper(baseConfigPath, "")
+	readConfig()
+
+	// 检查custom.yaml是否覆盖了config.yaml中的配置
+	req.True(BotConfig.DebugMode)
+	req.Equal("custom-token", BotConfig.Token)
 }

--- a/config/special_list.go
+++ b/config/special_list.go
@@ -11,6 +11,10 @@ type specialListConfig struct {
 func (c *specialListConfig) readConfig() {
 	c.Chats = make([]int64, 0)
 	c.Enabled = viper.GetBool(c.Name + ".enabled")
+	chats := viper.GetIntSlice(c.Name + ".chats")
+	for _, v := range chats {
+		c.Chats = append(c.Chats, int64(v))
+	}
 }
 
 func (c *specialListConfig) checkConfig() {

--- a/orm/redis.go
+++ b/orm/redis.go
@@ -32,17 +32,6 @@ func NewClient() *redis.Client {
 	})
 }
 
-// Ping can ping a redis client.
-// return true if ping success.
-func Ping(c *redis.Client) bool {
-	// TODO: replace ctx with real ctx
-	if _, err := c.Ping(context.TODO()).Result(); err != nil {
-		log.Error("ping redis failed", zap.Error(err))
-		return false
-	}
-	return true
-}
-
 func wrapKey(key string) string {
 	return config.BotConfig.RedisConfig.KeyPrefix + key
 }
@@ -83,15 +72,15 @@ func loadSpecialList(key string) []string {
 // LoadWhiteList load white list.
 func LoadWhiteList() {
 	chats := util.StringsToInts(loadSpecialList("white_list"))
-	log.Info("White List has load.", zap.Int("length", len(chats)))
-	config.BotConfig.WhiteListConfig.Chats = chats
+	config.BotConfig.WhiteListConfig.Chats = append(config.BotConfig.WhiteListConfig.Chats, chats...)
+	log.Info("White List has load.", zap.Int("length", len(config.BotConfig.WhiteListConfig.Chats)))
 }
 
 // LoadBlockList load black list.
 func LoadBlockList() {
 	chats := util.StringsToInts(loadSpecialList("black_list"))
-	log.Info("Block List has load.", zap.Int("length", len(chats)))
-	config.BotConfig.BlockListConfig.Chats = chats
+	config.BotConfig.BlockListConfig.Chats = append(config.BotConfig.BlockListConfig.Chats, chats...)
+	log.Info("Block List has load.", zap.Int("length", len(config.BotConfig.BlockListConfig.Chats)))
 }
 
 // IsNoStickerMode check group in NoSticker mode.


### PR DESCRIPTION
This pull request includes various changes to the configuration and Redis handling in the project. The most important changes involve adding support for custom configuration files, improving the special list configuration handling, and modifying how the white and black lists are loaded.

### Configuration Enhancements:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R107-R119): Added support to check for and merge a `custom.yaml` configuration file located in the same directory as the main configuration file.
* [`config/config_test.go`](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R224-R249): Added a new test `TestCustomConfig` to verify that the custom configuration file correctly overrides the main configuration file settings.

### Special List Configuration:

* [`config/special_list.go`](diffhunk://#diff-50e2b5bca730e47f4e7208f949cb7e3389ac64e96a480a80bdd0b81701c86e2bR14-R17): Updated `readConfig` method in `specialListConfig` to properly handle and convert integer slices from the configuration.

### Redis Handling:

* [`orm/redis.go`](diffhunk://#diff-bd7ce5cdbe47baad88938701727179aea5cb46c12b971282f180abfc3c8e43d5L35-L45): Removed the `Ping` function which was previously used to ping a Redis client.
* [`orm/redis.go`](diffhunk://#diff-bd7ce5cdbe47baad88938701727179aea5cb46c12b971282f180abfc3c8e43d5L86-R83): Modified `LoadWhiteList` and `LoadBlockList` functions to append chats to the existing list instead of replacing it.

### Minor Improvements:

* [`chat_v2/chat.go`](diffhunk://#diff-0975a58b1878d7c4fdd29af6402c679f3b086bb3e8ab3f74c926318c8688579eL9-R16): Reorganized import statements to follow a consistent order.
* `config/config.go` and `config/config_test.go`: Added the `filepath` package import to support new file path operations. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R5) [[2]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R5)