### PR TITLE
go: upgrade to 1.26

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.25
+          go-version: ^1.26
 
       - name: Install Go dependencies
         run: make deps

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.25
+          go-version: ^1.26
 
       - name: Get deps
         run: make deps

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.25
+          go-version: ^1.26
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.25
+          go-version: ^1.26
 
       - name: Get deps
         run: make deps

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 version: "2"
 run:
   concurrency: 16
-  go: "1.25"
+  go: "1.26"
   issues-exit-code: 1
   tests: true
   allow-parallel-runners: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: "1.25"
+go: "1.26"
 scripts:
   - make build
   - echo "Test Complete"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-This repo is a modern Telegram bot for CSUST built with Go 1.25+, featuring AI chat, message search (MeiliSearch), image generation (Stable Diffusion), gacha systems, and comprehensive permission controls.
+This repo is a modern Telegram bot for CSUST built with Go 1.26+, featuring AI chat, message search (MeiliSearch), image generation (Stable Diffusion), gacha systems, and comprehensive permission controls.
 
 ## Architecture Overview
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS buildenv
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS buildenv
 ARG TARGETARCH
 
 RUN apk add make git tzdata

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A modern Telegram bot for CSUST, developed in Go.
 
 ## System Requirements
 
-- Go 1.25+
+- Go 1.26+
 - Redis
 - Docker & Docker Compose (recommended)
 
@@ -180,7 +180,7 @@ setiwant - f=<format> vf=<format> sf=<format> Set sticker format
 
 ## Tech Stack
 
-- **Language**: Go 1.25+
+- **Language**: Go 1.26+
 - **Framework**: [telebot.v3](https://github.com/tucnak/telebot)
 - **Database**: Redis
 - **Search**: MeiliSearch

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -31,7 +31,7 @@
 
 ## 系统要求
 
-- Go 1.25+
+- Go 1.26+
 - Redis
 - Docker & Docker Compose（推荐）
 
@@ -180,7 +180,7 @@ setiwant - f=<format> vf=<format> sf=<format> 设置我要Sticker
 
 ## 技术栈
 
-- **语言**: Go 1.25+
+- **语言**: Go 1.26+
 - **框架**: [telebot.v3](https://github.com/tucnak/telebot)
 - **数据库**: Redis
 - **搜索**: MeiliSearch

--- a/chat/context_test.go
+++ b/chat/context_test.go
@@ -696,7 +696,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      2,
 					Text:    "Reply to original",
 					User:    "user2",
-					ReplyTo: intPtr(1),
+					ReplyTo: new(1),
 					UserNames: userNames{
 						First: "Jane",
 						Last:  "Smith",
@@ -729,7 +729,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      2,
 					Text:    "Reply to root",
 					User:    "user2",
-					ReplyTo: intPtr(1),
+					ReplyTo: new(1),
 					UserNames: userNames{
 						First: "Jane",
 						Last:  "Smith",
@@ -739,7 +739,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      3,
 					Text:    "Reply to reply",
 					User:    "user3",
-					ReplyTo: intPtr(2),
+					ReplyTo: new(2),
 					UserNames: userNames{
 						First: "Bob",
 						Last:  "Johnson",
@@ -775,7 +775,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      2,
 					Text:    "First reply",
 					User:    "user2",
-					ReplyTo: intPtr(1),
+					ReplyTo: new(1),
 					UserNames: userNames{
 						First: "Jane",
 						Last:  "Smith",
@@ -785,7 +785,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      3,
 					Text:    "Second reply",
 					User:    "user3",
-					ReplyTo: intPtr(1),
+					ReplyTo: new(1),
 					UserNames: userNames{
 						First: "Bob",
 						Last:  "Johnson",
@@ -830,7 +830,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      3,
 					Text:    "Reply to first root",
 					User:    "user3",
-					ReplyTo: intPtr(1),
+					ReplyTo: new(1),
 					UserNames: userNames{
 						First: "Bob",
 						Last:  "Johnson",
@@ -866,7 +866,7 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 					ID:      2,
 					Text:    "Reply with & more <tags>",
 					User:    "user2",
-					ReplyTo: intPtr(1),
+					ReplyTo: new(1),
 					UserNames: userNames{
 						First: "Jane",
 						Last:  "Smith",
@@ -911,9 +911,4 @@ func TestFormatContextMessagesWithXml(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
-}
-
-// Helper function to create int pointer
-func intPtr(i int) *int {
-	return &i
 }

--- a/chat/reaction_test.go
+++ b/chat/reaction_test.go
@@ -110,13 +110,13 @@ func TestAIResponseMetadata_AllowRegenerate(t *testing.T) {
 	}{
 		{
 			name:            "AllowRegenerate enabled",
-			allowRegenerate: boolPtr(true),
-			expected:        boolPtr(true),
+			allowRegenerate: new(true),
+			expected:        new(true),
 		},
 		{
 			name:            "AllowRegenerate disabled",
-			allowRegenerate: boolPtr(false),
-			expected:        boolPtr(false),
+			allowRegenerate: new(false),
+			expected:        new(false),
 		},
 		{
 			name:            "AllowRegenerate nil (legacy/not set)",
@@ -141,11 +141,6 @@ func TestAIResponseMetadata_AllowRegenerate(t *testing.T) {
 			assert.Equal(t, tt.expected, metadata.AllowRegenerate)
 		})
 	}
-}
-
-// boolPtr is a helper function to get a pointer to a bool value
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 func TestMessageContentExtraction(t *testing.T) {

--- a/chatv2/agent.go
+++ b/chatv2/agent.go
@@ -7,6 +7,7 @@ import (
 	"csust-got/config"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"text/template"
 
@@ -336,9 +337,7 @@ func mergeSkillConfigs(agentCfg *config.AgentConfig) (
 	mcpServers = append(mcpServers, agentCfg.McpServers...)
 
 	toolModels = make(map[string]*config.Model)
-	for k, v := range agentCfg.ToolModels {
-		toolModels[k] = v
-	}
+	maps.Copy(toolModels, agentCfg.ToolModels)
 
 	toolSeen := make(map[string]struct{})
 	for _, t := range agentCfg.Tools {

--- a/chatv2/image_context.go
+++ b/chatv2/image_context.go
@@ -109,8 +109,8 @@ func imageBase64RawEnabled(tc *TurnContext) bool {
 
 func stripDataURIPrefix(s string) string {
 	if strings.HasPrefix(s, "data:") {
-		if idx := strings.Index(s, ","); idx >= 0 {
-			return s[idx+1:]
+		if _, after, ok := strings.Cut(s, ","); ok {
+			return after
 		}
 	}
 	return s
@@ -206,10 +206,7 @@ func loadCurrentAlbumMessages(msg *tb.Message) []*tb.Message {
 }
 
 func loadAlbumSiblingMessages(chatID int64, messageID int, albumID string, messages map[int]*tb.Message) {
-	startID := messageID - currentAlbumSiblingWindow
-	if startID < 1 {
-		startID = 1
-	}
+	startID := max(messageID-currentAlbumSiblingWindow, 1)
 	endID := messageID + currentAlbumSiblingWindow
 
 	for id := startID; id <= endID; id++ {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	testConfigFile = "../config.yaml"
+	repoConfigFile = "../config.yaml"
 	testEnvPrefix  = "BOT_TEST"
 )
 
@@ -21,12 +21,26 @@ func testInit(t *testing.T) *require.Assertions {
 	return require.New(t)
 }
 
+func isolatedConfigFile(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile(repoConfigFile)
+	require.NoError(t, err)
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	err = os.WriteFile(configFile, data, 0o644)
+	require.NoError(t, err)
+
+	return configFile
+}
+
 func TestReadConfigFile(t *testing.T) {
 	req := testInit(t)
+	configFile := isolatedConfigFile(t)
 
 	// init config
 	BotConfig = NewBotConfig()
-	InitViper(testConfigFile, "")
+	InitViper(configFile, "")
 	readConfig()
 	viper.Reset()
 
@@ -75,6 +89,7 @@ func TestReadEnv(t *testing.T) {
 
 func TestEnvOverrideFile(t *testing.T) {
 	req := testInit(t)
+	configFile := isolatedConfigFile(t)
 
 	// set some env
 	t.Setenv(testEnvPrefix+"_"+"DEBUG", "true")
@@ -83,7 +98,7 @@ func TestEnvOverrideFile(t *testing.T) {
 
 	// init config
 	BotConfig = NewBotConfig()
-	InitViper(testConfigFile, testEnvPrefix)
+	InitViper(configFile, testEnvPrefix)
 	readConfig()
 	defer viper.Reset()
 
@@ -122,10 +137,11 @@ func TestMustConfig(t *testing.T) {
 
 func TestRateLimitConfig(t *testing.T) {
 	req := testInit(t)
+	configFile := isolatedConfigFile(t)
 
 	// init config
 	BotConfig = NewBotConfig()
-	InitViper(testConfigFile, testEnvPrefix)
+	InitViper(configFile, testEnvPrefix)
 	readConfig()
 	defer viper.Reset()
 
@@ -165,13 +181,14 @@ func TestRateLimitConfig(t *testing.T) {
 
 func TestMessageConfig(t *testing.T) {
 	req := testInit(t)
+	configFile := isolatedConfigFile(t)
 
 	// set some env
 	t.Setenv(testEnvPrefix+"_"+"TOKEN", "some-bot-token")
 	t.Setenv(testEnvPrefix+"_"+"REDIS_ADDR", "some-env-address")
 	// init config
 	BotConfig = NewBotConfig()
-	InitViper(testConfigFile, testEnvPrefix)
+	InitViper(configFile, testEnvPrefix)
 	readConfig()
 	defer viper.Reset()
 
@@ -188,6 +205,7 @@ func TestMessageConfig(t *testing.T) {
 
 func TestSpecialListConfig(t *testing.T) {
 	req := testInit(t)
+	configFile := isolatedConfigFile(t)
 
 	// set some env
 	t.Setenv(testEnvPrefix+"_"+"TOKEN", "some-bot-token")
@@ -196,7 +214,7 @@ func TestSpecialListConfig(t *testing.T) {
 	// init config
 	BotConfig = NewBotConfig()
 
-	InitViper(testConfigFile, testEnvPrefix)
+	InitViper(configFile, testEnvPrefix)
 	readConfig()
 
 	defer viper.Reset()
@@ -207,11 +225,12 @@ func TestSpecialListConfig(t *testing.T) {
 
 func TestChatConfigV1(t *testing.T) {
 	req := testInit(t)
+	configFile := isolatedConfigFile(t)
 
 	// init config
 	BotConfig = NewBotConfig()
 
-	InitViper(testConfigFile, testEnvPrefix)
+	InitViper(configFile, testEnvPrefix)
 	readConfig()
 
 	defer viper.Reset()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module csust-got
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cloudwego/eino v0.8.10


### PR DESCRIPTION
This pull request upgrades the project from Go 1.25 to Go 1.26 across all documentation, CI/CD workflows, and configuration files. It also introduces several code improvements, including replacing custom pointer helper functions with Go's built-in `new()` function, simplifying code in `chatv2/agent.go` and `chatv2/image_context.go`, and improving test isolation for configuration tests.

**Go version upgrade:**
* Bumped Go version from 1.25 to 1.26 in all CI/CD workflow files, Dockerfile, `.golangci.yaml`, `.travis.yml`, `go.mod`, and documentation (`README.md`, `README_zh-CN.md`, `AGENTS.md`). [[1]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL26-R26) [[2]](diffhunk://#diff-3854a2403943751bde7b490002c48d5fd271df3d3e4539fb8ec1270a29b410daL37-R37) [[3]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L17-R17) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L22-R22) [[5]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L4-R4) [[6]](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L2-R2) [[7]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L1-R1) [[8]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L183-R183) [[11]](diffhunk://#diff-97375d1e506d3bc28dab6e19ef5701d560c3e956f17d9e0d7c4c4e80b32a8d86L34-R34) [[12]](diffhunk://#diff-97375d1e506d3bc28dab6e19ef5701d560c3e956f17d9e0d7c4c4e80b32a8d86L183-R183) [[13]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3)

**Code simplification and modernization:**
* Replaced custom pointer helper functions (`intPtr`, `boolPtr`) with Go's built-in `new()` function in test files, and removed the now-unnecessary helper functions. [[1]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L915-L919) [[2]](diffhunk://#diff-3f635b16460a2e56224599ebf99be43e1db02a9030f3b99841892a40a43b2495L146-L150)
* Updated usage in tests to use `new()` instead of the removed helpers. (Fcdd9e5aL23R23, [[1]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L732-R732) [[2]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L742-R742) [[3]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L778-R778) [[4]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L788-R788) [[5]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L833-R833) [[6]](diffhunk://#diff-89c83fc808fbc308eacf0b4f9f558b266502f047c114c4e760e742c502afdb28L869-R869) [[7]](diffhunk://#diff-3f635b16460a2e56224599ebf99be43e1db02a9030f3b99841892a40a43b2495L113-R119)

**Code improvements and bug fixes:**
* Simplified copying maps in `chatv2/agent.go` by using `maps.Copy` instead of manual iteration. [[1]](diffhunk://#diff-2995996ed7994515a965e6da6d27a8e99ac420c7d890ee10398ab876c73c8ccaR10) [[2]](diffhunk://#diff-2995996ed7994515a965e6da6d27a8e99ac420c7d890ee10398ab876c73c8ccaL339-R340)
* Improved string parsing in `chatv2/image_context.go` by using `strings.Cut` for safer and clearer code.
* Simplified range calculation in `chatv2/image_context.go` using `max()` for clarity and correctness.

**Test improvements:**
* Improved config tests in `config/config_test.go` by introducing `isolatedConfigFile`, ensuring tests use a temporary, isolated config file and do not interfere with the repo config. [[1]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L15-R15) [[2]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R24-R43) [[3]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R92) [[4]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L86-R101) [[5]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R140-R144) [[6]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R184-R191) [[7]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R208) [[8]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L199-R217) [[9]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R228-R233)